### PR TITLE
Fix grunt test server from timing out on certain requests and throwing errros on invalid URL access

### DIFF
--- a/tasks/mocha_require_phantom.js
+++ b/tasks/mocha_require_phantom.js
@@ -64,7 +64,7 @@ module.exports = function(grunt) {
 		function launchServer(){
 			server.use(express.static(path.resolve('.')));
 			server.get('/**', function(req, res){
-				
+				var fileLoc= null;
 				if (req.url.indexOf(options.basePathForTests) >= 0) {
 					var url = req.url;
 					if (req.url.lastIndexOf('.') < req.url.lastIndexOf('/')) {
@@ -74,10 +74,7 @@ module.exports = function(grunt) {
 					if (url.charAt(0) === '/') {
 						url = url.substring(1, url.length);
 					}
-					
-					res.end(grunt.file.read(url, {
-						encoding: 'utf8'
-					}));
+					fileLoc= url;
 				} else if(req.url.indexOf('.') === -1 || req.url.lastIndexOf('.') < req.url.lastIndexOf('/')){
 					// the second condition takes care of relative paths like ../test.js vs ../test
 					
@@ -85,13 +82,20 @@ module.exports = function(grunt) {
 					if (file.indexOf(options.basePathForTests) == -1) {
 						file = options.basePathForTests + file + '.js';
 					}
-					
+
 					copyFiles();
-					writeBootstrap(file);				
-					res.end(grunt.file.read(tempDirectory + '/index.html', {
-						encoding: 'utf8'
-					}));
+					writeBootstrap(file);	
+					fileLoc= tempDirectory + '/index.html';
 				}
+				
+				if (fileLoc == null || !grunt.file.exists(fileLoc)) {
+					res.status(404).end();
+					return;
+				}
+				
+				res.end(grunt.file.read(fileLoc, {
+						encoding: 'utf8'
+				}));
 			});
 
 			server.listen(options.port);


### PR DESCRIPTION
Steps:

1) Run the task with the keepalive option
2) Enter any localhost:4000/randomUrlHere in the browser
3) Notice, the requests times out. 

This is because we never end the request if we miss both if statements in the request handler.

In addition, if the requests happens to be prefixed with basePathForTests, then we will get an error server side. Instead we should return a 404.
